### PR TITLE
introduce GitHub actions for push and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run test
+      uses: docker://nimlang/nim:1.0.0
+      with:
+        args: nimble test --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Release
+on: [release]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build artifact
+      uses: docker://nimlang/nim:1.0.0
+      with:
+        args: nimble build -d:ssl
+    - name: Upload artifacts
+      uses: skx/github-action-publish-binaries@release-0.7
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: 'nim_todo_issue'


### PR DESCRIPTION
This PR will add two workflows:

1. Build that runs `nimble test` 
2. Release that runs `nimble build` then upload artifact to release page (you need to create a release by your own)

Note that artifact is build on `nimlang/nim:1.0.0` then the built package should work on Ubuntu.
I'm personally not sure that it can run on other Linux distributions or not.